### PR TITLE
PFigura: string array (here called amporsnr) should have a length of …

### DIFF
--- a/search/network/openmp/init.c
+++ b/search/network/openmp/init.c
@@ -502,7 +502,7 @@ void add_signal(
   double sinaadd, cosaadd, sindadd, cosdadd, phaseadd, shiftadd; 
   double nSource[3], sgnlo[8], sgnlol[4];
  
-  char amporsnr[3];  
+  char amporsnr[4];  
  
   FILE *data;
   


### PR DESCRIPTION
…at least 4 characters. Otherwise various functions will not find end of string character ('\0') and can behave oddly.