### PR TITLE
[search] Adding an option for all triggers and correcting reading parameters in add_signal

### DIFF
--- a/search/network/openmp/init.c
+++ b/search/network/openmp/init.c
@@ -393,13 +393,6 @@ void add_signal( Search_settings *sett,
               printf("Problem with the signal file. Exiting...\n");
               exit(0);
           }
-
-          // Fscanning signal parameters: f, fdot, alpha, delta (sgnlo[0], ..., sgnlo[3])
-          // Intrinsic parameters: inclination, polarization, phase  (sgnlo[4], ..., sgnlo[6])
-          // (see sigen.c and Phys. Rev. D 82, 022005 2010, Eqs. 2.13a-d)
-          for(i=0; i<7; i++)
-               fscanf(data, "%le",i+sgnlo);
-
           fclose (data);
 
      } else {

--- a/search/network/openmp/jobcore.c
+++ b/search/network/openmp/jobcore.c
@@ -546,6 +546,12 @@ int job_core(
                int ic = i;
                FLOAT_TYPE Fc = F[ic];
                i++; // skip the next point as it can't be a local maximum
+#elif MAX_ALG == 4
+          #pragma omp parallel for default(shared) schedule(static)
+          for (i=s_range->fr[0]; i<=s_range->fr[1]; ++i) {
+               if (F[i] < opts->thr) continue;
+               int ic = i;
+               FLOAT_TYPE Fc = F[ic];
 #endif
 
                // Candidate signal frequency ( ~ ii/nmax * pi where nmax=nfftf/2 )


### PR DESCRIPTION
I added another option in jobcore.c to recover all triggers above a threshold instead of just the local maxima.

I also corrected the add_signal part to read the parameters properly (So it doesn't get overwritten).